### PR TITLE
Add recorder permission setting

### DIFF
--- a/app/src/main/java/com/android/check_in_listener/MainActivity.kt
+++ b/app/src/main/java/com/android/check_in_listener/MainActivity.kt
@@ -1,8 +1,14 @@
 package com.android.check_in_listener
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.provider.Settings
 import android.util.Log
+import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.android.check_in_listener.databinding.ActivityMainBinding
@@ -10,6 +16,10 @@ import com.android.check_in_listener.listenDb.ListenDatabase
 import com.android.check_in_listener.listenDb.ListenRoomData
 
 class MainActivity : AppCompatActivity(){
+
+    companion object {
+        const val PERMISSION_REQUEST_CODE = 17389
+    }
 
     private var _binding: ActivityMainBinding? = null
     private val binding get() = _binding!!
@@ -31,16 +41,53 @@ class MainActivity : AppCompatActivity(){
         })
 
         binding.btnListen.setOnClickListener {
-            if(!isListening) binding.btnListen.text = "수신중단"
-            else binding.btnListen.text = "수신버튼"
-            isListening = model.listener(isListening)
+
+            if (checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+                    != PackageManager.PERMISSION_GRANTED){
+                showDialogToGetPermission()
+            }else{
+                if(!isListening) binding.btnListen.text = "수신중단"
+                else binding.btnListen.text = "수신버튼"
+                isListening = model.listener(isListening)
+            }
         }
+
+        requestRecorderPermission()
+
     }
 
     private fun saveListenData(listenData: ListenRoomData){
         Thread(Runnable {
             listenDatabase?.listenDao()?.insert(listenData)
         }).start()
+    }
+
+    private fun requestRecorderPermission() {
+        if(checkSelfPermission(Manifest.permission.RECORD_AUDIO)
+                == PackageManager.PERMISSION_GRANTED){
+        }else{
+            requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO),
+                PERMISSION_REQUEST_CODE)
+        }
+    }
+
+    private fun showDialogToGetPermission() {
+        val builder = AlertDialog.Builder(this)
+        builder.setTitle("Permission request")
+            .setMessage("you need to allow recorder permission for receive data.")
+
+        builder.setPositiveButton("OK") { dialogInterface, i ->
+            val intent = Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", packageName, null))
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+        }
+        builder.setNegativeButton("Later") { dialogInterface, i ->
+
+        }
+        val dialog = builder.create()
+        dialog.show()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/android/check_in_listener/listenDb/ListenRoomData.kt
+++ b/app/src/main/java/com/android/check_in_listener/listenDb/ListenRoomData.kt
@@ -6,6 +6,6 @@ import androidx.room.PrimaryKey
 
 @Entity
 class ListenRoomData(
-    @PrimaryKey val personalNumber: String?,
+    @PrimaryKey val personalNumber: String,
     @ColumnInfo(name = "address") val address: String?
 )


### PR DESCRIPTION
일부 글에서 permission check 및 간단 dialog는 ViewModel이 아닌
View에서 해결하는 것이 좋다하여 View(MainActivity)에서 우선 적용해 보았습니다!!
![캡처1](https://user-images.githubusercontent.com/72801465/134687423-a03fbd1b-dbaa-4b77-9b8b-1d402a7e90fc.JPG)
https://developer.android.com/topic/libraries/architecture/viewmodel?hl=ko
https://github.com/android/architecture-components-samples/issues/48

실제로 permission을 체크할 수 있는 API(ex. checkSelfPermission 등)는
AppCompatActivity를 상속한 Activity에서만 사용이 가능하여
ViewModel에서는 적용이 쉽지 않았습니다ㅠㅠ

코드 검토하신 이후 더 나은 개선 방향이나 틀린 부분 있을 경우
피드백 주시면 감사하겠습니다!!
필요할 경우엔 해당 부분 관련하여 디스커션 생성하도록 하겠습니다!

![결과1](https://user-images.githubusercontent.com/72801465/134688186-8d744f74-5c5e-4046-9d7b-11c83b38da17.JPG)
- 초기 앱 실행 시 recorder 권한 허용 여부 선택 가능


![결과2](https://user-images.githubusercontent.com/72801465/134688222-839a9730-443e-4c81-b716-90cc28487832.JPG)
- 권한 비허용일때 수신 버튼 누를 경우 recorder 권한 허용 유도


![결과32](https://user-images.githubusercontent.com/72801465/134688242-39f29f06-e501-4541-a6f1-498f1690116c.JPG)
- 다이얼로그 OK 누를 경우 안드로이드 setting 으로 넘어가 권한 설정 가능

- ListenRoomData의 기본키에 null 값이 할당되는 이슈 해결(null 값 비허용)
